### PR TITLE
replace dry_run flag with diff_only

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Deploy an helm chart
 -   `devel`: _Optional._ Allow development versions of chart to be installed. This is useful when wanting to install pre-release
     charts (i.e. 1.0.2-rc1) without having to specify a version. (Default: false)
 -   `debug`: _Optional._ Dry run the helm install with the debug flag which logs interpolated chart templates. (Default: false)
--   `dryrun`: _Optional._ Dry run the helm install without the debug flag enabled. Useful in combination with show_diff. (Default: false)
+-   `diff_only`: _Optional._ Only run the helm diff command without running helm upgrade. (Default: false)
 -   `check_is_ready`: _Optional._ Requires that `wait` is set to Default. Applies --wait without timeout. (Default: false)
 -   `wait_for_jobs`: _Optional._ Requires that `wait` is set to Default. Applies --wait and --wait-for-jobs without timeout. (Default: false)
 -   `atomic`: _Optional._ This flag will cause failed installs to purge the release, and failed upgrades to rollback to the previous release. (Default: false)

--- a/assets/out
+++ b/assets/out
@@ -37,7 +37,7 @@ test_logs=$(jq -r '.params.test_logs // "false"' < $payload)
 devel=$(jq -r '.params.devel // "false"' < $payload)
 force=$(jq -r '.params.force // "false"' < $payload)
 show_diff=$(jq -r '.params.show_diff // "false"' < $payload)
-dryrun=$(jq -r '.params.dryrun // "false"' < $payload)
+diff_only=$(jq -r '.params.diff_only // "false"' < $payload)
 post_renderer=$(jq -r '.params.post_renderer // ""' < $payload)
 reuse_values=$(jq -r '.params.reuse_values // "false"' < $payload)
 reset_values=$(jq -r '.params.reset_values // "false"' < $payload)
@@ -180,10 +180,6 @@ helm_upgrade() {
     upgrade_args+=("--dry-run")
   fi
 
-  if [ "$dryrun" == "true" ]; then
-    upgrade_args+=("--dry-run")
-  fi
-
   if [ -n "$version" ]; then
     if [ -f "$source/$version" ]; then
       version=$(cat $source/$version)
@@ -241,16 +237,17 @@ helm_upgrade() {
     $helm_bin "${helm_depup_args[@]}" | tee "$logfile"
   fi
 
-  if [ "$show_diff" = true ] ; then
+  if [ "$show_diff" = true ] || [ "$diff_only" = true ] ; then
     echo "Release diff:"
     $helm_bin diff --no-color=false "${helm_diff_args[@]}" | tee "$logfile"
   fi
 
-  echo "Running command helm ${helm_echo_args[@]} | tee $logfile"
-  upgrade_result=$($helm_bin "${helm_args[@]}" | tee "$logfile")
-  echo "$upgrade_result"
-
-  deployed_release=$(echo $upgrade_result | head -n 1 | awk '{ print $2 }')
+  if [ "$diff_only" != true ] ; then
+    echo "Running command helm ${helm_echo_args[@]} | tee $logfile"
+    upgrade_result=$($helm_bin "${helm_args[@]}" | tee "$logfile")
+    echo "$upgrade_result"
+    deployed_release=$(echo $upgrade_result | head -n 1 | awk '{ print $2 }')
+  fi
 
   if [ -n "$wait" ] && [ "$wait" -gt "0" ]; then
     echo "Waiting for $wait Seconds"
@@ -325,7 +322,7 @@ else
   echo "Installing $release"
   helm_upgrade
 
-  if [ "$debug" != "true" ]; then
+  if [ "$debug" != "true" ] || [ "$diff_only" = "true" ] ; then
     # If release is empty
     if [ -z "$release" ]; then
       release=$deployed_release


### PR DESCRIPTION
Suppress any other output than from helm diff since we may have plain secrets in the output from the helm upgrade dry-run even without debug enabled